### PR TITLE
add initial ideas of interfaces

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -1,6 +1,7 @@
 package bucket
 
 import (
+	"github.com/mateusz/tempomat/lib/config"
 	"net/http"
 	"strings"
 	"sync"
@@ -10,25 +11,18 @@ type Bucket struct {
 	lowCreditThreshold float64
 	rate               float64
 	hashMaxLen         int
-	mutex              sync.RWMutex
+	sync.RWMutex
 }
 
-func (b *Bucket) SetLowCreditThreshold(lowCreditThreshold float64) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-	b.lowCreditThreshold = lowCreditThreshold
+func (b *Bucket) SetConfig(c config.Config) {
+	b.lowCreditThreshold = c.LowCreditThreshold
+	b.hashMaxLen = c.HashMaxLen
 }
 
-func (b *Bucket) SetRate(rate float64) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-	b.rate = rate
-}
-
-func (b *Bucket) SetHashMaxLen(hashMaxLen int) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-	b.hashMaxLen = hashMaxLen
+func (b *Bucket) Threshold() float64 {
+	b.RLock()
+	defer b.RUnlock()
+	return b.lowCreditThreshold
 }
 
 func getIPAdressFromHeaders(r *http.Request, m map[string]bool) string {

--- a/bucket/interfaces.go
+++ b/bucket/interfaces.go
@@ -1,0 +1,21 @@
+package bucket
+
+import (
+	"fmt"
+	"github.com/mateusz/tempomat/lib/config"
+	"net/http"
+)
+
+type Entry interface {
+	fmt.Stringer
+	Credits() float64
+}
+
+// stupid name
+type Bucketable interface {
+	Title() string // maybe this should be fmt.Stringer?
+	Entries() map[string]Entry
+	Register(r *http.Request, cost float64)
+	Threshold() float64
+	SetConfig(config.Config)
+}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"text/tabwriter"
+)
+
+type Config struct {
+	Debug              bool            `json:"debug"`
+	LowCreditThreshold float64         `json:"lowCreditThreshold"`
+	Backend            string          `json:"backend"`
+	ListenPort         int             `json:"listenPort"`
+	LogFile            string          `json:"logFile"`
+	StatsFile          string          `json:"statsFile"`
+	Graphite           string          `json:"graphite"`
+	GraphitePrefix     string          `json:"graphitePrefix"`
+	TrustedProxies     string          `json:"trustedProxies"`
+	Slash32Share       float64         `json:"slash32Share"`
+	Slash24Share       float64         `json:"slash24Share"`
+	Slash16Share       float64         `json:"slash16Share"`
+	UserAgentShare     float64         `json:"userAgentShare"`
+	HashMaxLen         int             `json:"hashMaxLen"`
+	GraphiteURL        *url.URL        `json:"-"`
+	TrustedProxiesMap  map[string]bool `json:"-"`
+}
+
+func New() Config {
+	return Config{
+		Debug:              false,
+		LowCreditThreshold: 0.1,
+		Backend:            "http://localhost:80",
+		ListenPort:         8888,
+		LogFile:            "",
+		StatsFile:          "",
+		Graphite:           "",
+		GraphitePrefix:     "",
+		TrustedProxies:     "",
+		Slash32Share:       0.1,
+		Slash24Share:       0.25,
+		Slash16Share:       0.5,
+		UserAgentShare:     0.1,
+		HashMaxLen:         1000,
+		GraphiteURL:        nil,
+		TrustedProxiesMap:  make(map[string]bool),
+	}
+}
+
+func (conf *Config) Print() {
+	const (
+		debugHelp              = "Debug mode"
+		lowCreditThresholdHelp = "Low credit threshold"
+		backendHelp            = "Backend URI"
+		listenPortHelp         = "Local HTTP listen port"
+		logFileHelp            = "Log file"
+		statsFileHelp          = "Stats file"
+		graphiteHelp           = "Graphite server, e.g. 'tcp://localhost:2003'"
+		graphitePrefixHelp     = "Graphite prefix, exclude final dot, e.g. 'chaos.schmall.prod'"
+		trustedProxiesHelp     = "Trusted proxy ips"
+		slash32ShareHelp       = "Slash32 max CPU share"
+		slash24ShareHelp       = "Slash24 max CPU share"
+		slash16ShareHelp       = "Slash16 max CPU share"
+		userAgentShareHelp     = "UserAgent max CPU share"
+		hashMaxLenHelp         = "Maximum amount of entries in the hash"
+	)
+	tw := tabwriter.NewWriter(os.Stdout, 24, 4, 1, ' ', tabwriter.AlignRight)
+	fmt.Fprint(tw, "Value\t   Option\f")
+	fmt.Fprintf(tw, "%t\t - %s\f", conf.Debug, debugHelp)
+	fmt.Fprintf(tw, "%d%%\t - %s\f", int(conf.LowCreditThreshold*100), lowCreditThresholdHelp)
+	fmt.Fprintf(tw, "%s\t - %s\f", conf.Backend, backendHelp)
+	fmt.Fprintf(tw, "%d\t - %s\f", conf.ListenPort, listenPortHelp)
+	fmt.Fprintf(tw, "%s\t - %s\f", conf.LogFile, logFileHelp)
+	fmt.Fprintf(tw, "%s\t - %s\f", conf.StatsFile, statsFileHelp)
+	fmt.Fprintf(tw, "%s\t - %s\f", conf.Graphite, graphiteHelp)
+	fmt.Fprintf(tw, "%s\t - %s\f", conf.GraphitePrefix, graphitePrefixHelp)
+	fmt.Fprintf(tw, "%s\t - %s\f", conf.TrustedProxies, trustedProxiesHelp)
+	fmt.Fprintf(tw, "%d%%\t - %s\f", int(conf.Slash32Share*100.0), slash32ShareHelp)
+	fmt.Fprintf(tw, "%d%%\t - %s\f", int(conf.Slash24Share*100.0), slash24ShareHelp)
+	fmt.Fprintf(tw, "%d%%\t - %s\f", int(conf.Slash16Share*100.0), slash16ShareHelp)
+	fmt.Fprintf(tw, "%d%%\t - %s\f", int(conf.UserAgentShare*100.0), userAgentShareHelp)
+	fmt.Fprintf(tw, "%d\t - %s\f", conf.HashMaxLen, hashMaxLenHelp)
+}


### PR DESCRIPTION
This is an untested example of using interfaces to expose bucket functionality, it's not driven to the extreme, just experimentation I did to show how I would have done it. Check the `bucket/interfaces.go`

This makes it possible in cmd.go to have a list of `Buckatable` (shitty naming) that works for most cases (beside the BucketDumper RPC call, where I added type assertion). 

And Entry is the individual entries in each Bucketable, as far as I can see they only need to expose how many credits they have and a debug output provided by String() (fmt.Stringer).

Now the main func only need to register new request and the buckets themselves takes care of increasing / decreasing the cost...

I also pass the Config into each bucket, so they can pick and grab what they want from it, `Tell, dont ask` princlple style.

But I might have missed some very crucial considerations you have made about the future API and what parts are doing what. I hope this is a better example of what I tried to say